### PR TITLE
Add SwiftPM support

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+      - name: Test as package
+        run: swift test
       - name: CocoaPod Install
         run: |
           cd PersonnummerExample

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.swiftpm/
+.build/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.6
+
+import PackageDescription
+
+let package = Package(
+    name: "Personnummer",
+    products: [
+        .library(name: "Personnummer", targets: ["Personnummer"]),
+    ],
+    targets: [
+        .target(
+            name: "Personnummer",
+            dependencies: [],
+            path: "source"
+        ),
+        .testTarget(
+            name: "PersonnummerTests",
+            dependencies: ["Personnummer"],
+            path: "PersonnummerExample/PersonnummerExampleTests",
+            exclude: ["Info.plist"]
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Small library to validate and format swedish personal identity numbers called "P
 pod 'Personnummer', '~> 1.0.0'
 ```
 
+### Swift Package Manager
+
+```swift
+.package(url: "https://github.com/personnummer/swift.git", from: "1.0.2")
+```
+
 ## Usage
 
 ```swift


### PR DESCRIPTION
**Type of change**
New feature

**Description**
This PR allows to install the library using Swift Package Manager.

**Motivation**
Many modern apps prefer using Swift Package Manager (SwiftPM) over CocoaPods for installing dependencies.

**Checklist**
- [x] I have read the **CONTRIBUTING** document.
- [x] I have read and accepted the **Code of conduct**
- [x] Tests passes.
- [x] Documentation is updated.